### PR TITLE
Added error for missing calc

### DIFF
--- a/src/Utils/Data/Config/Settings/LastCalculation.java
+++ b/src/Utils/Data/Config/Settings/LastCalculation.java
@@ -41,13 +41,13 @@ public class LastCalculation {
 
         } catch (NullPointerException npe) {
             PopupDisplay.throwErrorPopup(
-                    "Es gab scheinbar ein Problem beim abrufen deiner Einstellungen!",
+                    "Es gab scheinbar ein Problem beim Abrufen deiner Einstellungen!",
                     "Du hast scheinbar noch keine letzte Rechnung abgespeichert");
             return null;
         } catch (JsonSyntaxException | JsonIOException | FileNotFoundException e) {
 
             PopupDisplay.throwErrorPopup(
-                    "Es gab scheinbar ein Problem beim abrufen deiner Einstellungen!",
+                    "Es gab scheinbar ein Problem beim Abrufen deiner Einstellungen!",
                     e.getMessage());
             return null;
         }

--- a/src/Utils/Data/Config/Settings/LastCalculation.java
+++ b/src/Utils/Data/Config/Settings/LastCalculation.java
@@ -39,7 +39,12 @@ public class LastCalculation {
 
             return calcInfo;
 
-        } catch (JsonSyntaxException | JsonIOException | FileNotFoundException | NullPointerException e) {
+        } catch (NullPointerException npe) {
+            PopupDisplay.throwErrorPopup(
+                    "Es gab scheinbar ein Problem beim abrufen deiner Einstellungen!",
+                    "Du hast scheinbar noch keine letzte Rechnung abgespeichert");
+            return null;
+        } catch (JsonSyntaxException | JsonIOException | FileNotFoundException e) {
 
             PopupDisplay.throwErrorPopup(
                     "Es gab scheinbar ein Problem beim abrufen deiner Einstellungen!",


### PR DESCRIPTION
When a user tries to load his last calculation and he does not have one, they now get a better fitting error for that.